### PR TITLE
fix uuid生成错误问题

### DIFF
--- a/controller/common/upload.go
+++ b/controller/common/upload.go
@@ -64,7 +64,8 @@ func Upload(ctx iris.Context) {
 
 	timeDir := strconv.Itoa(year) + sep + monthStr + sep + dateStr
 
-	title := uuid.NewV4().String() + ext
+	uuidV4, _ := uuid.NewV4()
+	title := uuidV4.String() + ext
 
 	uploadDir := config.ServerConfig.UploadImgDir + sep + timeDir
 	mkErr := os.MkdirAll(uploadDir, 0777)


### PR DESCRIPTION
uuid包前段时间更新了，NewV4等方法的返回值增加了error，因此需要修改获取uuid的逻辑。